### PR TITLE
build script fixes for 15.06 branch

### DIFF
--- a/ubuntu-15.04-build-script.sh
+++ b/ubuntu-15.04-build-script.sh
@@ -1,17 +1,18 @@
-#!/bin/bash
+#/bin/bash
 # This is a script which get the latest git repo and build them.
 #
 # Tested under ubuntu 15.04, lower versions don't have PyQT 5.2.1 which is required by cura
 
 cd ~
-mkdir dev && cd dev
+mkdir -p dev && cd dev
 
 sudo apt-get install -y git cmake cmake-gui autoconf libtool python3-setuptools curl python3-pyqt5.* python3-numpy qml-module-qtquick-controls
-git clone https://github.com/Ultimaker/Cura.git
-git clone https://github.com/Ultimaker/Uranium.git
-git clone https://github.com/Ultimaker/CuraEngine.git
-git clone https://github.com/Ultimaker/libArcus
-git clone https://github.com/Ultimaker/protobuf.git
+curl -L https://github.com/Ultimaker/Cura/archive/15.06.03.tar.gz > Cura.tar.gz
+curl -L https://github.com/Ultimaker/Uranium/archive/15.06.03.tar.gz > Uranium.tar.gz
+curl -L https://github.com/Ultimaker/CuraEngine/archive/15.06.03.tar.gz > CuraEngine.tar.gz
+curl -L https://github.com/Ultimaker/libArcus/archive/15.06.03.tar.gz > libArcus.tar.gz
+curl -L https://github.com/Ultimaker/protobuf/archive/15.06.03.tar.gz > protobuf.tar.gz
+for file in *.tar.gz; do mkdir -p ${file%%.*}; tar -xvf $file --strip-components=1 -C ${file%%.*}; done
 
 cd protobuf
 ./autogen.sh
@@ -43,7 +44,10 @@ cmake .. -DPYTHON_SITE_PACKAGES_DIR=/usr/lib/python3.4/dist-packages -DURANIUM_P
 sudo make install
 cd ../..
 
-cp -rv Uranium/resources/* Cura/resources/
-sudo ln -s $PWD/CuraEngine/build/CuraEngine /usr/bin/CuraEngine
+#cp -rv Uranium/resources/* Cura/resources/
+ln -s $PWD/Uranium/resources/* Cura/resources/.
+ln -s $PWD/Uranium/plugins/* Cura/plugins/.
+mkdir bin
+ln -s $PWD/CuraEngine/build/CuraEngine bin/CuraEngine
 cd Cura
 python3 cura_app.py


### PR DESCRIPTION
I have a few touchups here.
- `mkdir dev && cd dev` is bad because if `mkdir dev` fails (dev already exists) then `cd dev` is skipped and everything happens in ~ :-/ 
- this build file (in the 15.06 branch) should not be cloning all of the latest git repos to do the build. Now it downloads the proper 15.06.03 release tarballs and builds from those
- The build script was not installing plugins properly, causing all kinds of strange errors
- CuraEngine doesn't seem to need to be put in /usr/bin (it's not even found there), instead it's found when placed in ~/dev/bin