### PR TITLE
build script fixes for master

### DIFF
--- a/ubuntu-15.04-build-script.sh
+++ b/ubuntu-15.04-build-script.sh
@@ -4,7 +4,7 @@
 # Tested under ubuntu 15.04, lower versions don't have PyQT 5.2.1 which is required by cura
 
 cd ~
-mkdir dev && cd dev
+mkdir -p dev && cd dev
 
 sudo apt-get install -y git cmake cmake-gui autoconf libtool python3-setuptools curl python3-pyqt5.* python3-numpy qml-module-qtquick-controls
 git clone https://github.com/Ultimaker/Cura.git
@@ -43,7 +43,9 @@ cmake .. -DPYTHON_SITE_PACKAGES_DIR=/usr/lib/python3.4/dist-packages -DURANIUM_P
 sudo make install
 cd ../..
 
-cp -rv Uranium/resources/* Cura/resources/
-sudo ln -s $PWD/CuraEngine/build/CuraEngine /usr/bin/CuraEngine
+ln -s $PWD/Uranium/resources/* Cura/resources/.
+ln -s $PWD/Uranium/plugins/* Cura/plugins/.
+mkdir bin
+ln -s $PWD/CuraEngine/build/CuraEngine bin/CuraEngine
 cd Cura
 python3 cura_app.py


### PR DESCRIPTION
- `mkdir dev && cd dev` is bad because if `mkdir dev` fails (dev already exists) then `cd dev` is skipped and everything happens in ~ :-/ 
- The build script was not installing plugins properly, causing all kinds of strange errors
- CuraEngine doesn't seem to need to be put in /usr/bin (it's not even found there), instead it's found when placed in ~/dev/bin