### PR TITLE
Qt5: Linux: Adding -qt-xcb to the list of options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,7 @@ if(BUILD_QT)
     elseif(BUILD_OS_WINDOWS)
         list(APPEND qt_options -opengl desktop)
     elseif(BUILD_OS_LINUX)
-        list(APPEND qt_options -no-rpath)
+        list(APPEND qt_options -no-rpath -qt-xcb)
     endif()
 
     ExternalProject_Add(Qt


### PR DESCRIPTION
For any reason a test made by qmake fails to use libxcb installed here (Ubuntu Xenial).
This will tell qmake to use Qt5's own copy of libxcb.