### PR TITLE
Qt5: Don't build bundled SQLite driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,7 @@ if(BUILD_QT)
         -nomake tests
         -nomake tools
         -no-cups
+        -no-sql-sqlite
         -skip qtconnectivity
         -skip qtdoc
         -skip qtenginio

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,7 +154,15 @@ if(BUILD_QT)
         -nomake tests
         -nomake tools
         -no-cups
+        -no-sql-db2
+        -no-sql-ibase
+        -no-sql-mysql
+        -no-sql-oci
+        -no-sql-odbc
+        -no-sql-psql
         -no-sql-sqlite
+        -no-sql-sqlite2
+        -no-sql-tds
         -skip qtconnectivity
         -skip qtdoc
         -skip qtenginio


### PR DESCRIPTION
By default qmake tries to provide it's own copy of SQLite to build a database driver. As far as I know we don't use SQLite or any other SQL database now.

This will add the needed option to build no SQL driver at all.