### PR TITLE
CMake: Remove some dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 include(ExternalProject)
 include(GNUInstallDirs)
 
+# Force to use "lib" as LIBDIR - ARCH uses "lib64" or "lib32" for example.
+set(LIBDIR "lib" CACHE FILEPATH "" FORCE)
+
 # Define Options
 option(BUILD_PYTHON "Include Python" ON)
 option(BUILD_QT "Include Qt" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -585,8 +585,6 @@ set(CPACK_RPM_PACKAGE_RELOCATABLE OFF)
 
 set(DEB_DEPENDS
     "python3 (>= 3.4.0)"
-    "python3 (<< 3.5.0)"
-    "python3-opengl (>= 3.0)"
     "libgfortran3"
 )
 string(REPLACE ";" "," DEB_DEPENDS "${DEB_DEPENDS}")


### PR DESCRIPTION
1. If we force to install Python 3.4, we won't get this DEB working on Ubuntu Xenial.
   Python 3.5 is provided here and Python 3.4 has been kicked out of the repositories.
2. Python-OpenGL module is not needed anymore, as we use a alternative workaround -> See Cura.
