### PR TITLE
[CURA-1749] Adding Numpy-STL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,6 @@ option(BUILD_PYQT "Include PyQt" ON)
 option(BUILD_NUMPY "Include Numpy" ON)
 option(BUILD_SCIPY "Include Scipy" ON)
 option(BUILD_PYSERIAL "Include PySerial" ON)
-option(BUILD_SETUPTOOLS "Include Setuptools" ON)
 option(BUILD_NUMPY_STL "Include Numpy-STL" ON)
 
 if(WIN32)
@@ -381,21 +380,9 @@ if(BUILD_PYSERIAL)
     )
 endif()
 
-if(BUILD_SETUPTOOLS)
-    ExternalProject_Add(Setuptools
-        DEPENDS Python
-        URL https://pypi.python.org/packages/45/5e/79ca67a0d6f2f42bfdd9e467ef97398d6ad87ee2fa9c8cdf7caf3ddcab1e/setuptools-23.0.0.tar.gz
-        URL_MD5 100a90664040f8ff232fbac02a4c5652
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND ${PYTHON_EXECUTABLE} setup.py build
-        INSTALL_COMMAND ${PYTHON_EXECUTABLE} setup.py install ${python_install}
-        BUILD_IN_SOURCE 1
-    )
-endif()
-
 if(BUILD_NUMPY_STL)
     ExternalProject_Add(NumpySTL
-        DEPENDS Python Setuptools
+        DEPENDS Python
         URL https://github.com/WoLpH/numpy-stl/archive/v1.9.0.tar.gz
         URL_MD5 cda2531edecff4468a4bbe78c6a2833b
         CONFIGURE_COMMAND ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,12 +328,13 @@ else()
 endif()
 
 if(BUILD_NUMPY)
-    set(build_numpy ${PYTHON_EXECUTABLE} setup.py build)
-    set(install_numpy ${PYTHON_EXECUTABLE} setup.py install ${python_install})
     if(BUILD_OS_LINUX)
         # Inform numpy about using OpenBLAS
         set(build_numpy "OPENBLAS=${EXTERNALPROJECT_INSTALL_PREFIX}/lib/libopenblas.so" ${build_numpy})
         set(install_numpy "OPENBLAS=${EXTERNALPROJECT_INSTALL_PREFIX}/lib/libopenblas.so" ${install_numpy})
+    else()
+        set(build_numpy ${PYTHON_EXECUTABLE} setup.py build)
+        set(install_numpy ${PYTHON_EXECUTABLE} setup.py install ${python_install})
     endif()
 
     ExternalProject_Add(Numpy
@@ -348,12 +349,13 @@ if(BUILD_NUMPY)
 endif()
 
 if(BUILD_SCIPY)
-    set(build_scipy ${PYTHON_EXECUTABLE} setup.py build)
-    set(install_scipy  ${PYTHON_EXECUTABLE} setup.py install ${python_install})
     if(BUILD_OS_LINUX)
         # Inform scipy about using OpenBLAS
         set(build_scipy "OPENBLAS=${EXTERNALPROJECT_INSTALL_PREFIX}/lib/libopenblas.so" "PYTHONPATH=${EXTERNALPROJECT_INSTALL_PREFIX}/lib/python3/dist-packages/" "LD_LIBRARY_PATH=${EXTERNALPROJECT_INSTALL_PREFIX}/lib" ${build_scipy})
         set(install_scipy "OPENBLAS=${EXTERNALPROJECT_INSTALL_PREFIX}/lib/libopenblas.so" "PYTHONPATH=${EXTERNALPROJECT_INSTALL_PREFIX}/lib/python3/dist-packages/" "LD_LIBRARY_PATH=${EXTERNALPROJECT_INSTALL_PREFIX}/lib" ${install_scipy})
+    else()
+        set(build_scipy ${PYTHON_EXECUTABLE} setup.py build)
+        set(install_scipy  ${PYTHON_EXECUTABLE} setup.py install ${python_install})
     endif()
 
     ExternalProject_Add(Scipy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ option(BUILD_PYQT "Include PyQt" ON)
 option(BUILD_NUMPY "Include Numpy" ON)
 option(BUILD_SCIPY "Include Scipy" ON)
 option(BUILD_PYSERIAL "Include PySerial" ON)
+option(BUILD_SETUPTOOLS "Include Setuptools" ON)
 
 if(WIN32)
     option(BUILD_64BIT "Create a 64-bit build" OFF)
@@ -377,6 +378,17 @@ if(BUILD_PYSERIAL)
     )
 endif()
 
+if(BUILD_SETUPTOOLS)
+    ExternalProject_Add(Setuptools
+        DEPENDS Python
+        URL https://pypi.python.org/packages/45/5e/79ca67a0d6f2f42bfdd9e467ef97398d6ad87ee2fa9c8cdf7caf3ddcab1e/setuptools-23.0.0.tar.gz
+        URL_MD5 100a90664040f8ff232fbac02a4c5652
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ${PYTHON_EXECUTABLE} setup.py build
+        INSTALL_COMMAND ${PYTHON_EXECUTABLE} setup.py install ${python_install}
+        BUILD_IN_SOURCE 1
+    )
+endif()
 if(BUILD_OS_OSX)
     set(protobuf_cxx_flags "-fPIC -std=c++11 -stdlib=libc++")
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ option(BUILD_NUMPY "Include Numpy" ON)
 option(BUILD_SCIPY "Include Scipy" ON)
 option(BUILD_PYSERIAL "Include PySerial" ON)
 option(BUILD_SETUPTOOLS "Include Setuptools" ON)
+option(BUILD_NUMPY_STL "Include Numpy-STL" ON)
 
 if(WIN32)
     option(BUILD_64BIT "Create a 64-bit build" OFF)
@@ -391,6 +392,19 @@ if(BUILD_SETUPTOOLS)
         BUILD_IN_SOURCE 1
     )
 endif()
+
+if(BUILD_NUMPY_STL)
+    ExternalProject_Add(NumpySTL
+        DEPENDS Python Setuptools
+        URL https://github.com/WoLpH/numpy-stl/archive/v1.9.0.tar.gz
+        URL_MD5 cda2531edecff4468a4bbe78c6a2833b
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND "PYTHONPATH=${EXTERNALPROJECT_INSTALL_PREFIX}/lib/python3/dist-packages/" ${PYTHON_EXECUTABLE} setup.py build
+        INSTALL_COMMAND "PYTHONPATH=${EXTERNALPROJECT_INSTALL_PREFIX}/lib/python3/dist-packages/" ${PYTHON_EXECUTABLE} setup.py install ${python_install}
+        BUILD_IN_SOURCE 1
+    )
+endif()
+
 if(BUILD_OS_OSX)
     set(protobuf_cxx_flags "-fPIC -std=c++11 -stdlib=libc++")
 else()


### PR DESCRIPTION
As needed for https://github.com/Ultimaker/Uranium/pull/143, here the addition of Numpy-STL into cura-build.

* It depends on python-setuptools, which is already included.
* Also includes a fix for messages, which appeared for me that OpenBLAS was not found.

A build with numpy-stl works here in a Ubuntu Wily chroot with Python3.4 installed by default.
Couldn't test the resulting .deb file, but I guess and I'm sure that numpy-stl should be available now,
as it appears in the inst/ directory.

Contributes to CURA-1749