### PR TITLE
GIT: Ignoring generated files and directories by CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,17 @@
+# CMake
+/*-prefix
+CMakeCache.txt
+CMakeFiles/
+CPackConfig.cmake
+CPackSourceConfig.cmake
+Makefile
+_CPack_Packages/
+cmake_install.cmake
+/inst/
+
+# CMake - Debian
+*.deb
+
 *.pyc
 *kdev*
 __pycache__


### PR DESCRIPTION
All of these files are generated, while configuring via "cmake ." and/or building via "make package".