### PR TITLE
[CURA-1919] 3MF (and other) file association fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -523,6 +523,8 @@ elseif(BUILD_OS_WINDOWS)
 endif()
 
 if(BUILD_OS_OSX)
+    set(CPACK_GENERATOR "DragNDrop")
+
     configure_file(setup_osx.py.in setup_osx.py @ONLY)
 
     add_custom_target(build_app ALL)
@@ -549,8 +551,9 @@ if(BUILD_OS_OSX)
 
     install(DIRECTORY ${CMAKE_BINARY_DIR}/dist/Cura.app DESTINATION "." USE_SOURCE_PERMISSIONS)
 
-    set(CPACK_GENERATOR "DragNDrop")
 elseif(BUILD_OS_WINDOWS)
+    set(CPACK_GENERATOR "NSIS")
+
     get_filename_component(compiler_dir ${CMAKE_CXX_COMPILER} DIRECTORY)
     configure_file(setup_win32.py.in setup_win32.py @ONLY)
 
@@ -563,6 +566,19 @@ elseif(BUILD_OS_WINDOWS)
         add_dependencies(build_exe ${name})
     endforeach()
 
+    # TODO: Find a variable which holds the needed "win32"/"win64"
+    if(BUILD_64BIT)
+        set(NSIS_SCRIPT_COPY_PATH "${CMAKE_BINARY_DIR}/_CPack_Packages/win64/${CPACK_GENERATOR}")
+    else()
+        set(NSIS_SCRIPT_COPY_PATH "${CMAKE_BINARY_DIR}/_CPack_Packages/win32/${CPACK_GENERATOR}")
+    endif()
+    
+    add_custom_command(
+        TARGET build_exe POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/${CPACK_GENERATOR} ${NSIS_SCRIPT_COPY_PATH}
+        COMMENT "Copying NSIS scripts"
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    )
     add_custom_command(
         TARGET build_exe PRE_LINK
         COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_BINARY_DIR}/dist
@@ -590,8 +606,6 @@ elseif(BUILD_OS_WINDOWS)
     cpack_add_component(cura DISPLAY_NAME "Cura Executable and Data Files" REQUIRED)
     cpack_add_component(vcredist DISPLAY_NAME "Install Visual Studio 2010 Redistributable")
     cpack_add_component(arduino DISPLAY_NAME "Install Arduino Drivers")
-
-    set(CPACK_GENERATOR "NSIS")
 elseif(BUILD_OS_LINUX)
     set(CPACK_GENERATOR "DEB")
 

--- a/NSIS/FileAssociation.nsh
+++ b/NSIS/FileAssociation.nsh
@@ -1,0 +1,190 @@
+/*
+_____________________________________________________________________________
+ 
+                       File Association
+_____________________________________________________________________________
+ 
+ Based on code taken from http://nsis.sourceforge.net/File_Association 
+ 
+ Usage in script:
+ 1. !include "FileAssociation.nsh"
+ 2. [Section|Function]
+      ${FileAssociationFunction} "Param1" "Param2" "..." $var
+    [SectionEnd|FunctionEnd]
+ 
+ FileAssociationFunction=[RegisterExtension|UnRegisterExtension]
+ 
+_____________________________________________________________________________
+ 
+ ${RegisterExtension} "[executable]" "[extension]" "[description]"
+ 
+"[executable]"     ; executable which opens the file format
+                   ;
+"[extension]"      ; extension, which represents the file format to open
+                   ;
+"[description]"    ; description for the extension. This will be display in Windows Explorer.
+                   ;
+ 
+ 
+ ${UnRegisterExtension} "[extension]" "[description]"
+ 
+"[extension]"      ; extension, which represents the file format to open
+                   ;
+"[description]"    ; description for the extension. This will be display in Windows Explorer.
+                   ;
+ 
+_____________________________________________________________________________
+ 
+                         Macros
+_____________________________________________________________________________
+ 
+ Change log window verbosity (default: 3=no script)
+ 
+ Example:
+ !include "FileAssociation.nsh"
+ !insertmacro RegisterExtension
+ ${FileAssociation_VERBOSE} 4   # all verbosity
+ !insertmacro UnRegisterExtension
+ ${FileAssociation_VERBOSE} 3   # no script
+*/
+ 
+ 
+!ifndef FileAssociation_INCLUDED
+!define FileAssociation_INCLUDED
+ 
+!include Util.nsh
+ 
+!verbose push
+!verbose 3
+!ifndef _FileAssociation_VERBOSE
+  !define _FileAssociation_VERBOSE 3
+!endif
+!verbose ${_FileAssociation_VERBOSE}
+!define FileAssociation_VERBOSE `!insertmacro FileAssociation_VERBOSE`
+!verbose pop
+ 
+!macro FileAssociation_VERBOSE _VERBOSE
+  !verbose push
+  !verbose 3
+  !undef _FileAssociation_VERBOSE
+  !define _FileAssociation_VERBOSE ${_VERBOSE}
+  !verbose pop
+!macroend
+ 
+ 
+ 
+!macro RegisterExtensionCall _EXECUTABLE _EXTENSION _DESCRIPTION
+  !verbose push
+  !verbose ${_FileAssociation_VERBOSE}
+  Push `${_DESCRIPTION}`
+  Push `${_EXTENSION}`
+  Push `${_EXECUTABLE}`
+  ${CallArtificialFunction} RegisterExtension_
+  !verbose pop
+!macroend
+ 
+!macro UnRegisterExtensionCall _EXTENSION _DESCRIPTION
+  !verbose push
+  !verbose ${_FileAssociation_VERBOSE}
+  Push `${_EXTENSION}`
+  Push `${_DESCRIPTION}`
+  ${CallArtificialFunction} UnRegisterExtension_
+  !verbose pop
+!macroend
+ 
+ 
+ 
+!define RegisterExtension `!insertmacro RegisterExtensionCall`
+!define un.RegisterExtension `!insertmacro RegisterExtensionCall`
+ 
+!macro RegisterExtension
+!macroend
+ 
+!macro un.RegisterExtension
+!macroend
+ 
+!macro RegisterExtension_
+  !verbose push
+  !verbose ${_FileAssociation_VERBOSE}
+ 
+  Exch $R2 ;exe
+  Exch
+  Exch $R1 ;ext
+  Exch
+  Exch 2
+  Exch $R0 ;desc
+  Exch 2
+  Push $0
+  Push $1
+ 
+  ReadRegStr $1 HKCR $R1 ""  ; read current file association
+  StrCmp "$1" "" NoBackup  ; is it empty
+  StrCmp "$1" "$R0" NoBackup  ; is it our own
+    WriteRegStr HKCR $R1 "backup_val" "$1"  ; backup current value
+NoBackup:
+  WriteRegStr HKCR $R1 "" "$R0"  ; set our file association
+ 
+  ReadRegStr $0 HKCR $R0 ""
+  StrCmp $0 "" 0 Skip
+    WriteRegStr HKCR "$R0" "" "$R0"
+    WriteRegStr HKCR "$R0\shell" "" "open"
+    WriteRegStr HKCR "$R0\DefaultIcon" "" "$R2,0"
+Skip:
+  WriteRegStr HKCR "$R0\shell\open\command" "" '"$R2" "%1"'
+  WriteRegStr HKCR "$R0\shell\edit" "" "Edit $R0"
+  WriteRegStr HKCR "$R0\shell\edit\command" "" '"$R2" "%1"'
+ 
+  Pop $1
+  Pop $0
+  Pop $R2
+  Pop $R1
+  Pop $R0
+ 
+  !verbose pop
+!macroend
+ 
+ 
+ 
+!define UnRegisterExtension `!insertmacro UnRegisterExtensionCall`
+!define un.UnRegisterExtension `!insertmacro UnRegisterExtensionCall`
+ 
+!macro UnRegisterExtension
+!macroend
+ 
+!macro un.UnRegisterExtension
+!macroend
+ 
+!macro UnRegisterExtension_
+  !verbose push
+  !verbose ${_FileAssociation_VERBOSE}
+ 
+  Exch $R1 ;desc
+  Exch
+  Exch $R0 ;ext
+  Exch
+  Push $0
+  Push $1
+ 
+  ReadRegStr $1 HKCR $R0 ""
+  StrCmp $1 $R1 0 NoOwn ; only do this if we own it
+  ReadRegStr $1 HKCR $R0 "backup_val"
+  StrCmp $1 "" 0 Restore ; if backup="" then delete the whole key
+  DeleteRegKey HKCR $R0
+  Goto NoOwn
+ 
+Restore:
+  WriteRegStr HKCR $R0 "" $1
+  DeleteRegValue HKCR $R0 "backup_val"
+  DeleteRegKey HKCR $R1 ;Delete key with association name settings
+ 
+NoOwn:
+ 
+  Pop $1
+  Pop $0
+  Pop $R1
+  Pop $R0
+ 
+  !verbose pop
+!macroend
+ 
+!endif # !FileAssociation_INCLUDED

--- a/NSIS/FileAssociation.nsh
+++ b/NSIS/FileAssociation.nsh
@@ -131,8 +131,10 @@ NoBackup:
     WriteRegStr HKCR "$R0\DefaultIcon" "" "$R2,0"
 Skip:
   WriteRegStr HKCR "$R0\shell\open\command" "" '"$R2" "%1"'
-  WriteRegStr HKCR "$R0\shell\edit" "" "Edit $R0"
-  WriteRegStr HKCR "$R0\shell\edit\command" "" '"$R2" "%1"'
+
+; Uncomment if you want a "Edit with XY" entry
+;  WriteRegStr HKCR "$R0\shell\edit" "" "Edit $R0"
+;  WriteRegStr HKCR "$R0\shell\edit\command" "" '"$R2" "%1"'
  
   Pop $1
   Pop $0

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -539,7 +539,7 @@ FunctionEnd
 ; Component sections
 @CPACK_NSIS_COMPONENT_SECTIONS@
 
-!include "@PROJECT_SOURCE_DIR@/NSIS/FileAssociation.nsh"
+!include "FileAssociation.nsh"
 
 Section "Open STL files with Cura"
     ${registerExtension} "$INSTDIR\Cura.exe" ".stl" "model via Cura"

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -539,43 +539,18 @@ FunctionEnd
 ; Component sections
 @CPACK_NSIS_COMPONENT_SECTIONS@
 
+!include "@PROJECT_SOURCE_DIR@/NSIS/FileAssociation.nsh"
+
 Section "Open STL files with Cura"
-    Push $0
-    Push $1
- 
-    ReadRegStr $1 HKCR .stl ""  ; read current file association
-    StrCmp "$1" "" NoBackup  ; is it empty
-    StrCmp "$1" "Cura.model.STL" NoBackup  ; is it our own
-        WriteRegStr HKCR .stl "backup_val" "$1"  ; backup current value
-NoBackup:
-    WriteRegStr HKCR .stl "" "Cura.model.STL"  ; set our file association
- 
-    ReadRegStr $0 HKCR Cura.model.STL ""
-    StrCmp $0 "" 0 Skip
-        WriteRegStr HKCR "Cura.model.STL" "" "Cura.model.STL"
-        WriteRegStr HKCR "Cura.model.STL\shell" "" "open"
-        WriteRegStr HKCR "Cura.model.STL\DefaultIcon" "" "$INSTDIR\Cura.exe,0"
-Skip:
-    WriteRegStr HKCR "Cura.model.STL\shell\open\command" "" '"$INSTDIR\Cura.exe" "%1"'
- 
-    Pop $1
-    Pop $0
+    ${registerExtension} "$INSTDIR\Cura.exe" ".stl" "model via Cura"
 SectionEnd
 
 Section /o "Open OBJ files with Cura"
-    WriteRegStr HKCR .obj "" "Wavefront OBJ Model File"
-    DeleteRegValue HKCR .obj "Content Type"
-    WriteRegStr HKCR "Cura OBJ model file\DefaultIcon" "" "$INSTDIR\Cura.exe,0"
-    WriteRegStr HKCR "Cura OBJ model file\shell" "" "open"
-    WriteRegStr HKCR "Cura OBJ model file\shell\open\command" "" '"$INSTDIR\Cura.exe" "%1"'
+    ${registerExtension} "$INSTDIR\Cura.exe" ".obj" "Cura.model.OBJ"
 SectionEnd
 
 Section /o "Open 3MF files with Cura"
-    WriteRegStr HKCR .3mf "" "3D Manufacturing Format"
-    DeleteRegValue HKCR .3mf "Content Type"
-    WriteRegStr HKCR "Cura 3MF model file\DefaultIcon" "" "$INSTDIR\Cura.exe,0"
-    WriteRegStr HKCR "Cura 3MF model file\shell" "" "open"
-    WriteRegStr HKCR "Cura 3MF model file\shell\open\command" "" '"$INSTDIR\Cura.exe" "%1"'
+    ${registerExtension} "$INSTDIR\Cura.exe" ".3mf" "Cura.model.3MF"
 SectionEnd
 
 ;--------------------------------

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -860,7 +860,7 @@ Section "Uninstall"
 
   ;Unregister file assiciations
   ${UnRegisterExtension} ".stl" "Cura.model.STL"
-  ${UnRegisterExtension} ".obj" "Cura.model.OBJ
+  ${UnRegisterExtension} ".obj" "Cura.model.OBJ"
   ${UnRegisterExtension} ".3mf" "Cura.model.3MF"
 
   ;Remove the uninstaller itself.

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -540,11 +540,26 @@ FunctionEnd
 @CPACK_NSIS_COMPONENT_SECTIONS@
 
 Section "Open STL files with Cura"
-    WriteRegStr HKCR .stl "" "STL Model File"
-    DeleteRegValue HKCR .stl "Content Type"
-    WriteRegStr HKCR "Cura STL model file\DefaultIcon" "" "$INSTDIR\Cura.exe,0"
-    WriteRegStr HKCR "Cura STL model file\shell" "" "open"
-    WriteRegStr HKCR "Cura STL model file\shell\open\command" "" '"$INSTDIR\Cura.exe" "%1"'
+    Push $0
+    Push $1
+ 
+    ReadRegStr $1 HKCR .stl ""  ; read current file association
+    StrCmp "$1" "" NoBackup  ; is it empty
+    StrCmp "$1" "Cura.model.STL" NoBackup  ; is it our own
+        WriteRegStr HKCR .stl "backup_val" "$1"  ; backup current value
+NoBackup:
+    WriteRegStr HKCR .stl "" "Cura.model.STL"  ; set our file association
+ 
+    ReadRegStr $0 HKCR Cura.model.STL ""
+    StrCmp $0 "" 0 Skip
+        WriteRegStr HKCR "Cura.model.STL" "" "Cura.model.STL"
+        WriteRegStr HKCR "Cura.model.STL\shell" "" "open"
+        WriteRegStr HKCR "Cura.model.STL\DefaultIcon" "" "$INSTDIR\Cura.exe,0"
+Skip:
+    WriteRegStr HKCR "Cura.model.STL\shell\open\command" "" '"$INSTDIR\Cura.exe" "%1"'
+ 
+    Pop $1
+    Pop $0
 SectionEnd
 
 Section /o "Open OBJ files with Cura"

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -542,15 +542,15 @@ FunctionEnd
 !include "FileAssociation.nsh"
 
 Section "Open STL files with Cura"
-    ${registerExtension} "$INSTDIR\Cura.exe" ".stl" "model via Cura"
+    ${RegisterExtension} "$INSTDIR\Cura.exe" ".stl" "Cura.model.STL"
 SectionEnd
 
 Section /o "Open OBJ files with Cura"
-    ${registerExtension} "$INSTDIR\Cura.exe" ".obj" "Cura.model.OBJ"
+    ${RegisterExtension} "$INSTDIR\Cura.exe" ".obj" "Cura.model.OBJ"
 SectionEnd
 
 Section /o "Open 3MF files with Cura"
-    ${registerExtension} "$INSTDIR\Cura.exe" ".3mf" "Cura.model.3MF"
+    ${RegisterExtension} "$INSTDIR\Cura.exe" ".3mf" "Cura.model.3MF"
 SectionEnd
 
 ;--------------------------------
@@ -857,6 +857,11 @@ Section "Uninstall"
   ;Remove the add/remove program
   Delete "$INSTDIR\AddRemove.exe"
 !endif
+
+  ;Unregister file assiciations
+  ${UnRegisterExtension} ".stl" "Cura.model.STL"
+  ${UnRegisterExtension} ".obj" "Cura.model.OBJ
+  ${UnRegisterExtension} ".3mf" "Cura.model.3MF"
 
   ;Remove the uninstaller itself.
   Delete "$INSTDIR\Uninstall.exe"


### PR DESCRIPTION
Just read the description above. Not only 3mf is troubling here (!).
Almost every file type which is already registered won't get linked with Cura.

This commit tells why and gives a possible, but likely non-working solution. Got no experiences with NSIS so far, but this kind of solution will to the trick.
https://github.com/Ultimaker/cura-build/commit/682670e0543a174b6db317b9aeae9f97bc1acd43

_NOTE_: Needs discussion here!