### PR TITLE
Using the latest stable protobuf release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,7 +422,8 @@ else()
 endif()
 
 ExternalProject_Add(Protobuf
-    URL https://github.com/google/protobuf/archive/v3.0.0-beta-2.tar.gz
+    URL https://github.com/google/protobuf/archive/v3.0.0.tar.gz
+    URL_MD5 d4f6ca65aadc6310b3872ee421e79fa6
     CONFIGURE_COMMAND ${CMAKE_COMMAND} -DCMAKE_INSTALL_PREFIX=${EXTERNALPROJECT_INSTALL_PREFIX} -DCMAKE_INSTALL_LIBDIR=lib -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_CXX_FLAGS=${protobuf_cxx_flags} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -G ${CMAKE_GENERATOR} ../Protobuf/cmake
 )
 


### PR DESCRIPTION
Would love to kick this commit directly into [master], but there might be a good reason why we are still using the beta.

For more on protobuf 3.0.0: https://github.com/google/protobuf/releases/tag/v3.0.0

PS: If we are lucky a more recent and stable protobuf codebase could fix some of our strange communication problems between CuraEngine <=> libArcus.