### PR TITLE
Add OctoPrintPlugin as a project

### DIFF
--- a/projects/Cura-OctoPrint.cmake
+++ b/projects/Cura-OctoPrint.cmake
@@ -1,0 +1,8 @@
+
+ExternalProject_Add(Cura-OctoPrint
+    GIT_REPOSITORY https://github.com/fieldOfView/OctoPrintPlugin
+    GIT_TAG origin/${TAG_OR_BRANCH}
+    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNALPROJECT_INSTALL_PREFIX} -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
+)
+
+SetProjectDependencies(TARGET Cura-OctoPrint DEPENDS Cura)


### PR DESCRIPTION
This PR adds the OctoPrintPlugin as a project to be packaged with Cura. This plugin allows the user to print directly to an OctoPrint instance, much like how you can print to an UM3.

This plugin is used by a lot of Cura users. The Lulzbot Edition of Cura2 will ship with this plugin, and so will future versions of the PPA distribution. This leaves the main distribution crippled in comparison.

This PR is an alternative approach to https://github.com/Ultimaker/Cura/pull/1766