### PR TITLE
Remove Doodle3d plugin package

### DIFF
--- a/projects/Cura-Doodle3D.cmake
+++ b/projects/Cura-Doodle3D.cmake
@@ -1,8 +1,0 @@
-
-ExternalProject_Add(Cura-Doodle3D
-    GIT_REPOSITORY https://github.com/Doodle3D/Doodle3D-cura-plugin
-    GIT_TAG origin/master
-    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNALPROJECT_INSTALL_PREFIX} -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
-)
-
-SetProjectDependencies(TARGET Cura-Doodle3D DEPENDS Cura)


### PR DESCRIPTION
This PR removes the Doodle3d package from Cura.

The package has not been functional for several versions of Cura. Cura refuses to load the plugin. There is no use in packaging it until it is fixed.