### PR TITLE
Run Cura without elevation from the installer

### DIFF
--- a/packaging/windows.cmake
+++ b/packaging/windows.cmake
@@ -75,7 +75,7 @@ set(CPACK_PACKAGE_INSTALL_DIRECTORY "Cura ${CURA_VERSION_MAJOR}.${CURA_VERSION_M
 set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
 set(CPACK_NSIS_EXECUTABLES_DIRECTORY ".")
 set(CPACK_NSIS_INSTALLED_ICON_NAME "Cura.ico")
-set(CPACK_NSIS_MUI_FINISHPAGE_RUN "Cura.exe")
+set(CPACK_NSIS_MUI_FINISHPAGE_RUN "\"$WINDIR\\explorer.exe\"\ Cura.exe") # Run Cura unelevated, see http://mdb-blog.blogspot.nl/2013/01/nsis-lunch-program-as-user-from-uac.html
 set(CPACK_NSIS_MENU_LINKS
     "https://ultimaker.com/en/support/software" "Cura Online Documentation"
     "https://github.com/ultimaker/cura" "Cura Development Resources"


### PR DESCRIPTION
When Cura is launched by the installer, it is run "As Administrator" (elevated), because the installer process runs elevated. This causes drag and drop not to work on first run, and python cache files to be written to the program files folder (which may in turn cause other issues).

Launching Cura through explorer.exe ensures that cura is ran as the currently logged in user. For details see http://mdb-blog.blogspot.nl/2013/01/nsis-lunch-program-as-user-from-uac.html

Fixes https://github.com/Ultimaker/Cura/issues/698, https://github.com/Ultimaker/Cura/issues/580, https://github.com/Ultimaker/Cura/issues/1467 and probably others.

See CURA-1767