### PR TITLE
Make sure to include OpenSSL libraries for Qt

### DIFF
--- a/packaging/setup_linux.py.in
+++ b/packaging/setup_linux.py.in
@@ -68,6 +68,10 @@ build_options = {
         "/usr/lib",
         "/usr/lib64",
     ],
+    "bin_includes": [
+        "libssl",
+        "libcrypto",
+    ],
     "bin_excludes": [
         "linux-vdso.so.1",
         "libpthread.so.0",

--- a/packaging/setup_win32.py.in
+++ b/packaging/setup_win32.py.in
@@ -101,6 +101,7 @@ build_options = {
         (PyQt5.__path__[0] + "/Qt/qml/QtQuick.2", "qml/QtQuick.2"),
     ],
     "excludes": [ ],
+    "bin_includes": ["libeay32", "ssleay32"],
     "replace_paths": [("*", "")],
 }
 


### PR DESCRIPTION
QtNetwork dynamically loads the OpenSSL libraries, which is why
cx_Freeze cannot find them, so make sure to manually include them.