### PR TITLE
NSIS: Adding missing uninstall dialogs until 2.7

### DIFF
--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -991,6 +991,8 @@ Function .onInit
   !insertmacro uninstallVersion "Cura 2.3" "Cura 2.3" "23"
   !insertmacro uninstallVersion "Cura 2.4" "Cura 2.4" "24"
   !insertmacro uninstallVersion "Cura 2.5" "Cura 2.5" "25"
+  !insertmacro uninstallVersion "Cura 2.6" "Cura 2.6" "26"
+  !insertmacro uninstallVersion "Cura 2.7" "Cura 2.7" "27"
   !insertmacro uninstallVersion "Cura" "@CPACK_PACKAGE_INSTALL_REGISTRY_KEY@" "latest"
 
 inst:


### PR DESCRIPTION
Looks like QA missed this somehow during their tests.
Intention is to motivate the user to uninstall old versions of Cura, because only the latest version of it gets active support.

In my opinion this needs to be added to the next patch-version, eg. 3.0.4.