### PR TITLE
packaging: Adding console application

### DIFF
--- a/packaging/setup_win32.py.in
+++ b/packaging/setup_win32.py.in
@@ -122,7 +122,13 @@ executables = [
                base="Win32GUI",
                targetName = "Cura.exe",
                icon="@CMAKE_SOURCE_DIR@/packaging/cura.ico"
-               )
+               ),
+    Executable(script="@EXTERNALPROJECT_INSTALL_PREFIX@/bin/cura_app.py",
+               base="Console",
+               targetName = "CuraCLI.exe",
+               icon="@CMAKE_SOURCE_DIR@/packaging/cura.ico"
+               ),
+    
 ]
 
 setup(


### PR DESCRIPTION
This will add a blocking CLI application. Normally after execution the application will be spawned in the background in Windows (it seems to me). However, since we are interested in headless usage of Cura, we need an executable, which is blocking until it is done. Anything else makes no sense for this use case.