### PR TITLE
cx_freeze: Adding include_msvcr

### DIFF
--- a/packaging/setup_win32.py.in
+++ b/packaging/setup_win32.py.in
@@ -113,7 +113,7 @@ build_options = {
         (PyQt5.__path__[0] + "/Qt/qml/QtQuick", "qml/QtQuick"),
         (PyQt5.__path__[0] + "/Qt/qml/QtQuick.2", "qml/QtQuick.2"),
     ],
-    "include_msvcr": True
+    "include_msvcr": True,
     "excludes": [ ],
     "replace_paths": [("*", "")],
 }

--- a/packaging/setup_win32.py.in
+++ b/packaging/setup_win32.py.in
@@ -113,6 +113,7 @@ build_options = {
         (PyQt5.__path__[0] + "/Qt/qml/QtQuick", "qml/QtQuick"),
         (PyQt5.__path__[0] + "/Qt/qml/QtQuick.2", "qml/QtQuick.2"),
     ],
+    "include_msvcr": True
     "excludes": [ ],
     "replace_paths": [("*", "")],
 }


### PR DESCRIPTION
Removes maybe the dependency of installing the msvcr libraries during installation?
Just found this one during some investigations:
https://stackoverflow.com/questions/24103105/how-to-link-msvcr100-dll-to-cx-freeze-program