### PR TITLE
Move plugins into plugin explorer

### DIFF
--- a/projects/Cura-OctoPrint.cmake
+++ b/projects/Cura-OctoPrint.cmake
@@ -1,8 +1,0 @@
-
-ExternalProject_Add(Cura-OctoPrint
-    GIT_REPOSITORY https://github.com/fieldOfView/OctoPrintPlugin
-    GIT_TAG origin/${TAG_OR_BRANCH}
-    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNALPROJECT_INSTALL_PREFIX} -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
-)
-
-SetProjectDependencies(TARGET Cura-OctoPrint DEPENDS Cura)

--- a/projects/Cura-PostProcessing.cmake
+++ b/projects/Cura-PostProcessing.cmake
@@ -1,8 +1,0 @@
-
-ExternalProject_Add(Cura-PostProcessing
-    GIT_REPOSITORY https://github.com/nallath/PostProcessingPlugin
-    GIT_TAG origin/${TAG_OR_BRANCH}
-    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNALPROJECT_INSTALL_PREFIX} -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
-)
-
-SetProjectDependencies(TARGET Cura-PostProcessing DEPENDS Cura)


### PR DESCRIPTION
In my point of view all plugins should be at one place.
This PR removes the last 2 plugins from cura-build.