### PR TITLE
README: Removing orphaned BUILD_64BIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ cd cura-build
 mkdir build
 cd build
 ..\env_win64.bat
-cmake -G "MinGW Makefiles" -DBUILD_64BIT:BOOL=ON ..
+cmake -G "MinGW Makefiles" ..
 mingw32-make
 mingw32-make package
 ```


### PR DESCRIPTION
According to my setup, CMake tells me each time, that this variable is unknown now.