### PR TITLE
Dont install arduino drivers when silent install

### DIFF
--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -747,9 +747,11 @@ Section "-Core installation"
 
   IntCmp $arduino_selected 0 +6
   ${If} ${RunningX64}
-    ExecWait '"$INSTDIR\arduino\dpinst-amd64.exe" /lm /sw'
+    IfSilent +2
+      ExecWait '"$INSTDIR\arduino\dpinst-amd64.exe" /lm /sw'
   ${Else}
-    ExecWait '"$INSTDIR\arduino\dpinst-x86.exe" /lm /sw'
+    IfSilent +2
+      ExecWait '"$INSTDIR\arduino\dpinst-x86.exe" /lm /sw'
   ${EndIf}
 
 @CPACK_NSIS_EXTRA_INSTALL_COMMANDS@

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -742,6 +742,8 @@ Section "-Core installation"
 
   !insertmacro MUI_STARTMENU_WRITE_END
 
+  ; Do not install the VS C++ redistributable package in silent installation
+  IfSilent +3
   IntCmp $vcredist_selected 0 +2
   ExecWait '"$INSTDIR\vcredist_x@CPACK_NSIS_PACKAGE_ARCHITECTURE@.exe" /install /quiet /norestart'
 

--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -745,12 +745,12 @@ Section "-Core installation"
   IntCmp $vcredist_selected 0 +2
   ExecWait '"$INSTDIR\vcredist_x@CPACK_NSIS_PACKAGE_ARCHITECTURE@.exe" /install /quiet /norestart'
 
+  ; Do not install the arduino driver in silent installation
+  IfSilent +7
   IntCmp $arduino_selected 0 +6
   ${If} ${RunningX64}
-    IfSilent +2
       ExecWait '"$INSTDIR\arduino\dpinst-amd64.exe" /lm /sw'
   ${Else}
-    IfSilent +2
       ExecWait '"$INSTDIR\arduino\dpinst-x86.exe" /lm /sw'
   ${EndIf}
 


### PR DESCRIPTION
This should fixes issue https://github.com/Ultimaker/Cura/issues/1245 

Thank you to @basictheprogram for pointing out that https://github.com/Ultimaker/Cura/blob/master/installer.nsi is not actually used and for suggesting the fix

I didn't see @basictheprogram make a PR so I've made this one, if he has made a PR and I've missed it please merge his and close this