### PR TITLE
Add !include "x64.nsh"

### DIFF
--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -44,6 +44,7 @@
 
   !include Sections.nsh
   !Include Library.nsh
+  !include "x64.nsh"
 
 ;--- Component support macros: ---
 ; The code for the add/remove functionality is from:


### PR DESCRIPTION
Add !include "x64.nsh" so that 32bit installer writes/reads from 64bit registry.