### PR TITLE
[4.0] CURA-6068 Package openssl.cnf

### DIFF
--- a/packaging/cura.sh
+++ b/packaging/cura.sh
@@ -8,4 +8,6 @@ export QML2_IMPORT_PATH=$scriptdir/qt/qml
 export QT_QPA_FONTDIR=/usr/share/fonts
 export QT_XKB_CONFIG_ROOT=/usr/share/X11/xkb
 
+export OPENSSL_CONF=$scriptdir/openssl.cnf
+
 cura "$@"

--- a/packaging/cura.sh
+++ b/packaging/cura.sh
@@ -8,6 +8,7 @@ export QML2_IMPORT_PATH=$scriptdir/qt/qml
 export QT_QPA_FONTDIR=/usr/share/fonts
 export QT_XKB_CONFIG_ROOT=/usr/share/X11/xkb
 
+# Use the openssl.cnf packaged in the AppImage
 export OPENSSL_CONF=$scriptdir/openssl.cnf
 
 cura "$@"

--- a/packaging/setup_linux.py.in
+++ b/packaging/setup_linux.py.in
@@ -70,6 +70,7 @@ build_options = {
         ("@CMAKE_PREFIX_PATH@/lib/qml", "qt/qml"),
         ("@CMAKE_PREFIX_PATH@/lib/libgeos.so", ""),
         ("@CMAKE_PREFIX_PATH@/lib/libgeos_c.so", ""),
+        ("/etc/pki/tls/openssl.cnf", ""),   # We probably can remove this when we compile a dedicated OpenSSL
     ],
     "optimize": 2,
     "bin_path_includes": [


### PR DESCRIPTION
This fixes a problem with OpenSSL on Fedora 29, which has a newer OpenSSL