### PR TITLE
Set LD_LIBRARY_PATH for cx_Freeze so it finds the right libraries

### DIFF
--- a/packaging/linux.cmake
+++ b/packaging/linux.cmake
@@ -12,7 +12,7 @@ add_custom_command(
 
 add_custom_command(
     TARGET packaging PRE_BUILD
-    COMMAND ${Python3_EXECUTABLE} setup.py build
+    COMMAND env "LD_LIBRARY_PATH=${CMAKE_PREFIX_PATH}/lib" ${Python3_EXECUTABLE} setup.py build
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     COMMENT "Running cx_Freeze to generate executable..."
 )


### PR DESCRIPTION
We need cx_Freeze to find our Qt libraries not the system libraries.
