### PR TITLE
Add option to build offline (no git updates) and new target 'update'.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,12 @@ cmake_minimum_required(VERSION 3.6)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
+option(BUILD_OFFLINE "Build offline (use target 'update' to update sources)." ON)
+
+if(BUILD_OFFLINE)
+	set_property(DIRECTORY PROPERTY EP_UPDATE_DISCONNECTED 1)
+endif()
+
 include(ExternalProject)
 include(GNUInstallDirs)
 
@@ -73,6 +79,8 @@ if(NOT CURA_EXTRA_PROJECTS_DIR STREQUAL "")
     file(GLOB _extra_projects ${CURA_EXTRA_PROJECTS_DIR}/*.cmake)
     list(APPEND _projects ${_extra_projects})
 endif()
+
+add_custom_target(update COMMENT "Updating Projects...")
 
 foreach(_project ${_projects})
     # Go through all files in projects/ and include them. The project files should define

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.6)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
-option(BUILD_OFFLINE "Build offline (use target 'update' to update sources)." ON)
+option(BUILD_OFFLINE "Build offline (use target 'update' to update sources)." OFF)
 
 if(BUILD_OFFLINE)
 	set_property(DIRECTORY PROPERTY EP_UPDATE_DISCONNECTED 1)

--- a/projects/Cura.cmake
+++ b/projects/Cura.cmake
@@ -4,6 +4,7 @@ ExternalProject_Add(Cura
     GIT_REPOSITORY https://github.com/ultimaker/Cura
     GIT_TAG origin/${CURA_BRANCH_OR_TAG}
     GIT_SHALLOW 1
+    STEP_TARGETS update
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNALPROJECT_INSTALL_PREFIX}
                -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
                -DURANIUM_SCRIPTS_DIR=
@@ -15,3 +16,5 @@ ExternalProject_Add(Cura
 )
 
 SetProjectDependencies(TARGET Cura DEPENDS Uranium CuraEngine)
+
+add_dependencies(update Cura-update)

--- a/projects/CuraEngine.cmake
+++ b/projects/CuraEngine.cmake
@@ -18,6 +18,7 @@ ExternalProject_Add(CuraEngine
     GIT_REPOSITORY https://github.com/ultimaker/CuraEngine
     GIT_TAG origin/${CURAENGINE_BRANCH_OR_TAG}
     GIT_SHALLOW 1
+    STEP_TARGETS update
     CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                -DCMAKE_INSTALL_PREFIX=${EXTERNALPROJECT_INSTALL_PREFIX}
                -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
@@ -29,3 +30,5 @@ ExternalProject_Add(CuraEngine
 )
 
 SetProjectDependencies(TARGET CuraEngine)
+
+add_dependencies(update CuraEngine-update)

--- a/projects/ExtraRepository.cmake
+++ b/projects/ExtraRepository.cmake
@@ -25,10 +25,13 @@ foreach(extra_repository ${EXTRA_REPOSITORIES})
     ExternalProject_Add(${extra_repository_name}
         GIT_REPOSITORY ${extra_repository_url}
         GIT_TAG origin/master
+        STEP_TARGETS update
         GIT_SHALLOW 1
         CMAKE_ARGS ${extra_repository_cmake_opts}
     )
 
     SetProjectDependencies(TARGET ${extra_repository_name} DEPENDS Cura)
+
+    add_dependencies(update ${extra_repository_name}-update)
 
 endforeach()

--- a/projects/Uranium.cmake
+++ b/projects/Uranium.cmake
@@ -11,7 +11,10 @@ ExternalProject_Add(Uranium
     GIT_REPOSITORY https://github.com/ultimaker/Uranium
     GIT_TAG origin/${URANIUM_BRANCH_OR_TAG}
     GIT_SHALLOW 1
+    STEP_TARGETS update
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNALPROJECT_INSTALL_PREFIX} -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
 )
 
 SetProjectDependencies(TARGET Uranium)
+
+add_dependencies(update Uranium-update)

--- a/projects/cura-binary-data.cmake
+++ b/projects/cura-binary-data.cmake
@@ -1,8 +1,11 @@
 ExternalProject_Add(cura-binary-data
     GIT_REPOSITORY https://github.com/ultimaker/cura-binary-data
     GIT_TAG origin/${CURABINARYDATA_BRANCH_OR_TAG}
+    STEP_TARGETS update
     GIT_SHALLOW 1
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNALPROJECT_INSTALL_PREFIX}
 )
 
 SetProjectDependencies(TARGET cura-binary-data DEPENDS Cura)
+
+add_dependencies(update cura-binary-data-update)

--- a/projects/fdm_materials.cmake
+++ b/projects/fdm_materials.cmake
@@ -1,8 +1,11 @@
 ExternalProject_Add(fdm_materials
     GIT_REPOSITORY https://github.com/ultimaker/fdm_materials
     GIT_TAG origin/${FDMMATERIALS_BRANCH_OR_TAG}
+    STEP_TARGETS update
     GIT_SHALLOW 1
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNALPROJECT_INSTALL_PREFIX} -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
 )
 
 SetProjectDependencies(TARGET fdm_materials DEPENDS Cura)
+
+add_dependencies(update fdm_materials-update)

--- a/projects/libCharon.cmake
+++ b/projects/libCharon.cmake
@@ -1,8 +1,11 @@
 ExternalProject_Add(libCharon
     GIT_REPOSITORY https://github.com/Ultimaker/libCharon
     GIT_TAG origin/${LIBCHARON_BRANCH_OR_TAG}
+    STEP_TARGETS update
     GIT_SHALLOW 1
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNALPROJECT_INSTALL_PREFIX} -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
 )
 
 SetProjectDependencies(TARGET libCharon)
+
+add_dependencies(update libCharon-update)


### PR DESCRIPTION
This should make building much quicker and more reliable.

For some reason, the git updates on Windows often fail which stops the build process. So this PR disables updates by default and adds a new target 'update' which can be executed once before doing the build, packaging, etc.