### PR TITLE
Make marketplace link configurable through cura-build

### DIFF
--- a/projects/Cura.cmake
+++ b/projects/Cura.cmake
@@ -19,6 +19,7 @@ ExternalProject_Add(Cura
                -DCURA_CLOUD_API_ROOT=${CURA_CLOUD_API_ROOT}
                -DCURA_CLOUD_API_VERSION=${CURA_CLOUD_API_VERSION}
                -DCURA_CLOUD_ACCOUNT_API_ROOT=${CURA_CLOUD_ACCOUNT_API_ROOT}
+               -DCURA_MARKETPLACE_ROOT=${CURA_MARKETPLACE_ROOT}
                -DCURA_NO_INSTALL_PLUGINS=${_cura_no_install_plugins}
 )
 


### PR DESCRIPTION
This way we can set this link in our build system to the staging version if necessary.

This is a requirement for https://github.com/Ultimaker/Cura/pull/6988.

Contributes to issue CURA-7071.