### PR TITLE
Quote all usages of scriptdir so that it may contain spaces.

### DIFF
--- a/packaging/cura.sh
+++ b/packaging/cura.sh
@@ -2,13 +2,13 @@
 
 scriptdir=$(dirname $0)
 
-export PYTHONPATH=$scriptdir/lib/python3.5
-export QT_PLUGIN_PATH=$scriptdir/qt/plugins
-export QML2_IMPORT_PATH=$scriptdir/qt/qml
+export PYTHONPATH="$scriptdir/lib/python3.5"
+export QT_PLUGIN_PATH="$scriptdir/qt/plugins"
+export QML2_IMPORT_PATH="$scriptdir/qt/qml"
 export QT_QPA_FONTDIR=/usr/share/fonts
 export QT_XKB_CONFIG_ROOT=/usr/share/X11/xkb
 
 # Use the openssl.cnf packaged in the AppImage
-export OPENSSL_CONF=$scriptdir/openssl.cnf
+export OPENSSL_CONF="$scriptdir/openssl.cnf"
 
 cura "$@"


### PR DESCRIPTION
Fix the problem that if the AppImage file name contains a space, it becomes unusable.

Fixes https://github.com/Ultimaker/Cura/issues/7051.