### PR TITLE
Windows: Force cache files to exist on install.

### DIFF
--- a/packaging/windows.cmake
+++ b/packaging/windows.cmake
@@ -28,6 +28,12 @@ add_custom_command(
     COMMENT "copying cura.ico as Cura.ico into package/"
 )
 
+add_custom_command(
+    TARGET build_bundle POST_BUILD
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/packaging/windows_touchcache.py -f ${CMAKE_BINARY_DIR}/package/
+    COMMENT "force cache files to be registered to the installer"
+)
+
 #
 # CURA-6074
 # QTBUG-57832

--- a/packaging/windows_touchcache.py
+++ b/packaging/windows_touchcache.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+SHORT_PY_VERSION = str(sys.version_info[0]) + str(sys.version_info[1])
+
+
+def touchCache(path: str) -> bool:
+    """
+    On Windows, when installing into a writable folder (not 'Program Files'),
+    python and qml generate cache files next to the source files.
+    On uninstall, those should be gone.
+    In order to do that seamlessly, the installer/uninstaller needs to know about these files beforehand.
+    The solution taken here is to generate 0-byte versions of those files, just before the packaging runs.
+
+    :param path: Top level folder
+    :return: Success (True) or exception (False).
+    """
+    if path.endswith("/") or path.endswith("\\") or path.endswith("\""):
+        path = path[0:-1]
+    create_files = []  # List[str]
+
+    try:
+        for root, _, filenames in os.walk(path):
+            for filename in filenames:
+
+                if filename.endswith(".py"):
+                    pyc_filename = filename[0:-3] + ".cpython-" + SHORT_PY_VERSION + ".pyc"
+                    create_files.append(os.path.join(root, "__pycache__", pyc_filename))
+
+                if filename.endswith(".qml"):
+                    qmlc_filename = filename + "c"
+                    create_files.append(os.path.join(root, qmlc_filename))
+
+    except IOError as ex:
+        print("Could not read folder (recursively) {} because {}".format(path, str(ex)))
+        return False
+
+    try:
+        for filename in create_files:
+            dirname = os.path.dirname(filename)
+            if not os.path.exists(dirname):
+                os.makedirs(dirname)
+            Path(filename).touch()
+
+    except IOError as ex:
+        print("Could not write to folder {} because {}".format(path, str(ex)))
+        return False
+
+    return True
+
+
+def mainfunc():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-f", "--folder", type = str, default = "")
+    args = parser.parse_args()
+    touchCache(args.folder)
+
+
+if __name__ == "__main__":
+    sys.exit(mainfunc())


### PR DESCRIPTION
... so the uninstaller can actually remove them, and thus the enitre folder.
part of CURA-7136