### PR TITLE
Allow build to run on other Docker machines

### DIFF
--- a/scripts/python3.5/linux/build.sh
+++ b/scripts/python3.5/linux/build.sh
@@ -77,7 +77,7 @@ set -e
 docker run \
   ${DOCKER_EXTRA_ARGS} \
   --rm \
-  --user 1000:1000 \
+  --user $(id -u):$(id -g) \
   --volume "$(pwd)":/home/ultimaker/src \
   --env CURA_BUILD_OUTPUT_DIR=/home/ultimaker/src/output \
   --env CURA_BRANCH_OR_TAG="${CURA_BRANCH_OR_TAG}" \

--- a/scripts/python3.7/linux/build.sh
+++ b/scripts/python3.7/linux/build.sh
@@ -75,7 +75,7 @@ set -e
 docker run \
   ${DOCKER_EXTRA_ARGS} \
   --rm \
-  --user 1000:1000 \
+  --user $(id -u):$(id -g) \
   --volume "$(pwd)":/home/ultimaker/src \
   --env CURA_BUILD_OUTPUT_DIR=/home/ultimaker/src/output \
   --env CURA_BRANCH_OR_TAG="${CURA_BRANCH_OR_TAG}" \


### PR DESCRIPTION
The linux/build.sh script is executed by a user on a docker machine. This user could have a different userid, or userid 1000 might not exist, so with this change we execute the docker container with the same userid and groupid as the user that's executing the script.

This allows the script to be executed on Google's Container Optimised OS (https://cloud.google.com/container-optimized-os/docs) which we use for running Rundeck on Cloud Run.