### PR TITLE
Look for the DLLs directory when copying numpy to the installer bundle

### DIFF
--- a/packaging/setup_win32.py.in
+++ b/packaging/setup_win32.py.in
@@ -22,7 +22,7 @@ def load_numpy(finder, module):
     finder.IncludePackage("numpy.linalg._umath_linalg")
 
     # Include all MKL files that are needed to get Numpy with MKL working.
-    npy_core_dir = os.path.join(module.path[0], "core")
+    npy_dll_dir = os.path.join(module.path[0], "DLLs")
     required_mkl_files = [
         "mkl_intel_thread.dll",
         "mkl_core.dll",
@@ -48,7 +48,7 @@ def load_numpy(finder, module):
         ])
 
     for file in required_mkl_files:
-        finder.IncludeFiles(os.path.join(npy_core_dir, file), file)
+        finder.IncludeFiles(os.path.join(npy_dll_dir, file), file)
 
 hooks.load_numpy = load_numpy
 


### PR DESCRIPTION
After updating the dependencies we no longer have to copy the `numpy` dlls to its core directory. As a result, we need to make sure `cx_Freeze` can find the required files.

Contributes to issue CURA-8400 and CURA-8403 and needs to be reviewed and checked together with https://github.com/Ultimaker/cura-build-environment/pull/107